### PR TITLE
Add Doxygen documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,8 @@ bin/*
 # build dir
 build/
 
+# docs dir
+docs/
+
 # temporary files
 *~

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,8 @@
+PROJECT_NAME = lines-are-beautiful
+PROJECT_NUMBER = 0.0
+PROJECT_BRIEF = "A C++ file API for the reMarkable e-ink tablet"
+
+INPUT = include/rmlab
+
+OUTPUT_DIRECTORY = docs
+RECURSIVE = YES

--- a/include/rmlab/Layer.hpp
+++ b/include/rmlab/Layer.hpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -17,6 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * @file
+ * Definition of layers.
+ */
+
 #pragma once
 
 #include "Line.hpp"
@@ -27,14 +32,25 @@
 
 namespace rmlab
 {
+    /**
+     * Element of a page, containing a set of lines.
+     *
+     * When inside the same layer, a line A is rendered above another line B
+     * if and only if it A comes after B in the layer order.
+     *
+     * @see rmlab::Page
+     * @see rmlab::Line
+     */
     struct Layer
     {
-        // .lines info
+        /**
+         * Number of lines in this layer.
+         */
         int32_t nlines;
-        
-        // meta
-        // current layer no.
-        // is this layer visible
+
+        /**
+         * All lines contained in this layer, in the order they were drawn.
+         */
         std::list< Line > lines;
     };
 }

--- a/include/rmlab/Line.hpp
+++ b/include/rmlab/Line.hpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -17,6 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * @file
+ * Definition of lines and of the magic numbers that encode their attributes.
+ */
+
 #pragma once
 
 #include "Point.hpp"
@@ -27,54 +32,174 @@
 
 namespace rmlab
 {
+/**
+ * Types of brushes.
+ *
+ * Each brush defines the texture and sensitivity of strokes that are applied
+ * to the canvas when the pen is used. Brush type can be selected using the
+ * GUI. There is exactly one brush type associated with each line.
+ *
+ * | Brush Type    | Pressure  |   Speed   |   Tilt    |
+ * | ------------- |:---------:|:---------:|:---------:|
+ * | Ballpoint pen |     X     |           |           |
+ * | Marker pen    |     X     |           |     X     |
+ * | Fineliner pen |           |           |           |
+ * | Sharp pencil  |           |           |           |
+ * | Tilt pencil   |     X     |           |     X     |
+ * | Brush         |     X     |     X     |     X     |
+ *
+ * Refer to <https://blog.remarkable.com/f53c8faeab77> for a visual overview
+ * of the differences between the brush types.
+ */
 namespace Brushes
 {
-    // see: https://blog.remarkable.com/how-to-find-your-perfect-writing-instrument-for-notetaking-on-remarkable-f53c8faeab77
     enum Brushes
     {
-        // pens
-        pen1 = 2u,          // GUI: 1-1 "ballpoint"
-        pen2 = 3u,          // GUI: 1-2 "marker"
-        fineliner = 4u,     // GUI: 1-3 "fineliner"
-        // pencils
-        pencil_sharp = 7u,  // GUI: 2-1 "sharp pencil"
-        pencil_tilt = 1u,   // GUI: 2-2 "tilt pencil"
-        // other
-        brush = 0u,         // GUI: 3 "brush"
-        highlighter = 5u,   // GUI: 5 (always color 0)
-        // not a line
-        rubber = 6u,        // GUI: 6-1 "eraser"
-        unknown_brush = 7u, // ? maybe "clear page" or "select"?
-        rubber_area = 8u    // GUI: 6-2 "area eraser"
+        /**
+         * Ballpoint pen.
+         */
+        pen1 = 2u,
+
+        /**
+         * Marker pen.
+         */
+        pen2 = 3u,
+
+        /**
+         * Fineliner pen.
+         */
+        fineliner = 4u,
+
+        /**
+         * Sharp pencil.
+         */
+        pencil_sharp = 7u,
+
+        /**
+         * Tilt pencil.
+         */
+        pencil_tilt = 1u,
+
+        /**
+         * Brush.
+         */
+        brush = 0u,
+
+        /**
+         * Highlighter.
+         */
+        highlighter = 5u,
+
+        /**
+         * Normal eraser.
+         */
+        rubber = 6u,
+
+        /**
+         * Maybe “clear page” or “select”?
+         */
+        unknown_brush = 7u,
+
+        /**
+         * Area eraser.
+         */
+        rubber_area = 8u
     };
 }
+
+/**
+ * Shades of grey.
+ *
+ * Defines the color of the brush used for a line. As the reMarkable uses a
+ * E Ink display, it only handles shades of grey (no colors). There is
+ * exactly one color selected for each line.
+ */
 namespace Colors
 {
     enum Colors
     {
+        /**
+         * Black color.
+         */
         black = 0u,
+
+        /**
+         * Grey color.
+         */
         grey = 1u,
+
+        /**
+         * White color.
+         */
         white = 2u
     };
 }
 
+/**
+ * Base brush sizes.
+ *
+ * Defines the base width of the brush used for a line, in pixel units. This
+ * size can be further affected by the pressure and tilt parameters, for
+ * brushes that support it.
+ */
 namespace BaseSizes
 {
+    /**
+     * Small size.
+     */
     constexpr float small = 1.875;
+
+    /**
+     * Medium size.
+     */
     constexpr float mid = 2.0;
+
+    /**
+     * Large size.
+     */
     constexpr float large = 2.125;
 }
 
+    /**
+     * Element of a layer, containing a set of points resulting from
+     * a single brush stroke.
+     *
+     * @see rmlab::Layer
+     * @see rmlab::Point
+     */
     struct Line
     {
-        // .lines info
+        /**
+         * Kind of brush that was selected while drawing the line.
+         * @see rmlab::Brushes
+         */
         int32_t brush_type;
+
+        /**
+         * Color of the brush as selected while drawing the line.
+         * @see rmlab::Colors
+         */
         int32_t color;
+
+        /**
+         * Attribute whose purpose is still unknown.
+         */
         int32_t unknown_line_attribute;
-        float brush_base_size;  // 1.875, 2.0, 2.125
+
+        /**
+         * Base size of the brush as selected while drawing the line.
+         * @see rmlab::BaseSizes
+         */
+        float brush_base_size;
+
+        /**
+         * Number of points in this line.
+         */
         int32_t npoints;
 
-        // meta
+        /**
+         * All points contained in this line, in the order they were drawn.
+         */
         std::list< Point > points;
     };
 }

--- a/include/rmlab/Notebook.cpp
+++ b/include/rmlab/Notebook.cpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/include/rmlab/Notebook.hpp
+++ b/include/rmlab/Notebook.hpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -17,6 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * @file
+ * Definition of notebooks.
+ */
+
 #pragma once
 
 #include <cstdint>  // int8_t - int64_t
@@ -28,16 +33,38 @@
 
 namespace rmlab
 {
+    /**
+     * Base unit of the reMarkable note-taking system, used similarly
+     * to a real-world notebook. It is made up of a set of pages.
+     *
+     * @see rmlab::Page
+     */
     struct Notebook
     {
-        // .lines info
+        /**
+         * Number of pages in this notebook.
+         */
         int32_t npages;
-        
-        // meta
+
+        /**
+         * Path to the binary file containing from which the notebook
+         * has been read.
+         */
         std::string filename;
+
+        /**
+         * All the pages of this notebook.
+         */
         std::list< Page > pages;
 
         Notebook() = delete;
+
+        /**
+         * Open a notebook.
+         *
+         * @param openFilename Path to the file containing the notebook
+         * data following the `.lines` format.
+         */
         Notebook( std::string const openFilename );
         ~Notebook();
     };

--- a/include/rmlab/Page.hpp
+++ b/include/rmlab/Page.hpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -17,6 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * @file
+ * Definition of pages.
+ */
+
 #pragma once
 
 #include "Layer.hpp"
@@ -27,13 +32,26 @@
 
 namespace rmlab
 {
+    /**
+     * Element of a notebook, containing a stack of layers.
+     *
+     * The layers at the top of the stack (or at the end of the list) are
+     * rendered last, meaning that they will appear above others.
+     *
+     * @see rmlab::Notebook
+     * @see rmlab::Layer
+     */
     struct Page
     {
-        // .lines info
+        /**
+         * Number of layers in this page.
+         */
         int32_t nlayers;
 
-        // meta
-        // current page no.
+        /**
+         * All the layers of this page, from the bottom to the top of the
+         * layer stack.
+         */
         std::list< Layer > layers;
     };
 }

--- a/include/rmlab/Point.hpp
+++ b/include/rmlab/Point.hpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -17,6 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * @file
+ * Definition of points and of the magic numbers that encode their attributes.
+ */
+
 #pragma once
 
 #include <cmath>
@@ -26,28 +31,98 @@ namespace rmlab
 {
 namespace ranges
 {
+    /**
+     * Rectangle in which the points are located.
+     */
     enum Coords
     {
+        /**
+         * Minimum value of the X coordinate, or X coordinate
+         * of the left-side of the bounding rectangle.
+         */
         minX = 0u,
+
+        /**
+         * Maximum value of the X coordinate, or X coordinate
+         * of the right-side of the bounding rectangle.
+         */
         maxX = 1404u,
+
+        /**
+         * Minimum value of the Y coordinate, or Y coordinate
+         * of the upper-side of the bounding rectangle.
+         */
         minY = 0u,
+
+        /**
+         * Maximum value of the Y coordinate, or Y coordinate
+         * of the bottom-side of the bounding rectangle.
+         */
         maxY = 1872u,
     };
 
+    /**
+     * Minimum pressure value.
+     */
     constexpr float minP = 0.0;
+
+    /**
+     * Maximum pressure value.
+     */
     constexpr float maxP = 1.0;
 
+    /**
+     * Minimum rotation value of the pen, in radians.
+     */
     constexpr float minRot = -M_PI / 2.0;
+
+    /**
+     * Maximum rotation value of the pen, in radians.
+     */
     constexpr float maxRot =  M_PI / 2.0;
 }
 
+    /**
+     * Element of a line. A line is made up of a sequence of points
+     * sampled at a constant interval.
+     */
     struct Point
     {
-        // .lines info
+        /**
+         * Position on the X-axis, relative to the upper-left corner
+         * of the device’s screen. This value is expressed in pixels
+         * and is comprised between rmlab::ranges::Coords::minX and
+         * rmlab::ranges::Coords::maxX.
+         */
         float x;
+
+        /**
+         * Position on the Y-axis, relative to the upper-left corner
+         * of the device’s screen. This value is expressed in pixels
+         * and is comprised between rmlab::ranges::Coords::minY and
+         * rmlab::ranges::Coords::maxY.
+         */
         float y;
+
+        /**
+         * Pressure that was being applied on the screen with the pen when
+         * this point was sampled. This value is comprised between
+         * rmlab::ranges::minP and rmlab::ranges::maxP.
+         */
         float pressure;
+
+        /**
+         * Rotation of the pen around the X axis when this point was sampled.
+         * This rotation is expressed in radians and comprised between
+         * rmlab::ranges::minRot and rmlab::ranges::maxRot.
+         */
         float rotX;
+
+        /**
+         * Rotation of the pen around the Y axis when this point was sampled.
+         * This rotation is expressed in radians and comprised between
+         * rmlab::ranges::minRot and rmlab::ranges::maxRot.
+         */
         float rotY;
     };
 }

--- a/include/rmlab/renderer/lines2png.cpp
+++ b/include/rmlab/renderer/lines2png.cpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/include/rmlab/rmlab.hpp
+++ b/include/rmlab/rmlab.hpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -15,6 +15,45 @@
  * You should have received a copy of the GNU General Public License
  * along with lines-are-beautiful.
  * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @mainpage lines-are-beautiful
+ *
+ * A C++ file API for the [reMarkable e-ink tablet](https://remarkable.com).
+ *
+ * **Warning:** The libraries and tools in this project are not (yet) hardened
+ * for malicious input. Only process files that you can trust with it!
+ *
+ * \section Overview
+ *
+ * The [reMarkable tablet](https://remarkable.com/) is a E Ink device that can
+ * be written on. It can be used as a note-taking device, for annotating or
+ * reading digital books. User notes are stored in so-called “notebooks” that
+ * behave just like real-life notebooks.
+ *
+ * This library implements reading the `.lines` binary file format, used by
+ * the device to store notebooks. The data structures are modeled after the
+ * ones found into this format, namely:
+ *
+ * | Structure       | Role                                                  |
+ * | --------------- | ----------------------------------------------------- |
+ * | rmlab::Notebook | Entry point.                                          |
+ * | rmlab::Page     | Each notebook is made up of several pages.            |
+ * | rmlab::Layer    | Each page contains a stack of layers.                 |
+ * | rmlab::Line     | A line is a stroke of the pen, stored inside a layer. |
+ * | rmlab::Point    | A line contains a sequence of sampled points.         |
+ *
+ * For a complete overview of the file format, see
+ * [this blog post by Axel Hübl.](https://plasma.ninja/blog/devices/remarkable/binary/format/2017/12/26/reMarkable-lines-file-format.html)
+ *
+ * \section Disclaimer
+ *
+ * This is a hobby project.
+ *
+ * The author(s) and contributor(s) are not associated with reMarkable AS,
+ * Norway. **reMarkable** is a registered trademark of *reMarkable AS* in
+ * some countries. Please see <https://remarkable.com> for their product.
  */
 
 #pragma once


### PR DESCRIPTION
Hello!

First of all, thank you for taking the time to decode the `.lines` format. This is my attempt at writing some docs in the Doxygen format so as to make the library easier to grasp for those who might not have read your blog post, and as a foundation for later developments.

The documentation can be generated using the `doxygen` CLI, and then found into `docs/html/index.html`. This also generates LaTeX source. May I also suggest hosting this somewhere (Github Pages?) to avoid the burden of cloning the repo and generating the docs?

Please let me know if I misinterpreted anything while documenting.