### PR TITLE
Make logging optional while decoding files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ function(rmlab_option name description default)
 endfunction()
 
 rmlab_option(PNG "Enable support for PNG conversion" AUTO)
+option(Rmlab_ENABLE_LOGGING "Log debugging information to standard error")
+
+if(Rmlab_ENABLE_LOGGING)
+    add_definitions(-DRMLAB_ENABLE_LOGGING)
+endif()
 
 # TODO: add defines via configure to installed header files
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,6 @@ function(rmlab_option name description default)
 endfunction()
 
 rmlab_option(PNG "Enable support for PNG conversion" AUTO)
-option(Rmlab_ENABLE_LOGGING "Log debugging information to standard error")
-
-if(Rmlab_ENABLE_LOGGING)
-    add_definitions(-DRMLAB_ENABLE_LOGGING)
-endif()
 
 # TODO: add defines via configure to installed header files
 
@@ -117,8 +112,14 @@ add_executable(lines2svg
 
 set_property(TARGET lines2svg PROPERTY CXX_STANDARD 11)
 target_link_libraries(lines2svg PRIVATE Rmlab)
+list(APPEND Rmlab_EXTRA_TARGETS lines2svg)
 
-set(Rmlab_EXTRA_TARGETS ${Rmlab_EXTRA_TARGETS} lines2svg)
+add_executable(dump
+    include/rmlab/tool/dump.cpp
+)
+set_property(TARGET dump PROPERTY CXX_STANDARD 11)
+target_link_libraries(dump PRIVATE Rmlab)
+list(APPEND Rmlab_EXTRA_TARGETS dump)
 
 # Generate Files with Configuration Options ###################################
 #

--- a/include/rmlab/Notebook.cpp
+++ b/include/rmlab/Notebook.cpp
@@ -26,12 +26,6 @@
 #include <fstream>
 #include <iostream>
 
-#ifdef RMLAB_ENABLE_LOGGING
-#define LOG(arg) (std::cerr << arg)
-#else
-#define LOG(arg)
-#endif
-
 
 namespace rmlab
 {
@@ -47,8 +41,6 @@ namespace detail
 
         fstream.read( (char*)&curPoint.x, sizeof(float) );
         fstream.read( (char*)&curPoint.y, sizeof(float) );
-        LOG( "              coords: " << curPoint.x << ", "
-                << curPoint.y << '\n' );
 
         // pressure and rotation of the pen to page normal
         // rotation: for centrially symmetric brushes as now, one attribute
@@ -60,9 +52,6 @@ namespace detail
         fstream.read( (char*)&curPoint.rotX, sizeof(float) );
         // range [-pi/2:pi/2]
         fstream.read( (char*)&curPoint.rotY, sizeof(float) );
-        LOG( "            pressure: " << curPoint.pressure << '\n' );
-        LOG( "       rot to X axis: " << curPoint.rotX << '\n' );
-        LOG( "       rot to Y axis: " << curPoint.rotY << '\n' );
 
         curLine.points.emplace_back( curPoint );
     }
@@ -84,27 +73,20 @@ namespace detail
         // select 4:   5 (marker/highlighter: always color 0)
         // what is/was 6? :-)
         fstream.read( (char*)&curLine.brush_type, sizeof(int32_t) );
-        LOG( "      brush type:  " << curLine.brush_type << '\n' );
 
         // color (0: black, 1: grey, 2: white)
         fstream.read( (char*)&curLine.color, sizeof(int32_t) );
-        LOG( "      color int32: " << curLine.color << '\n' );
 
         // unknown 4 Byte (int32_t?), always zero?
         // non-stored information about "selected" lines?
         fstream.read( (char*)&curLine.unknown_line_attribute, sizeof(int32_t) );
-        LOG( "      magic 4byte:  " << curLine.unknown_line_attribute << '\n' );
 
         // brush base size: 1.875, 2.0, 2.125
         fstream.read( (char*)&curLine.brush_base_size, sizeof(float) );
-        LOG( "      brush size:  " << curLine.brush_base_size << '\n' );
-
         fstream.read( (char*)&curLine.npoints, sizeof(int32_t) );
-        LOG( "      no. points: " << curLine.npoints << '\n' );
 
         for( int n = 0; n < curLine.npoints; ++n )
         {
-            LOG( "      point " << n << " --------------------\n" );
             readPoint( fstream, curLine );
         }
 
@@ -119,11 +101,9 @@ namespace detail
     {
         Layer curLayer;
         fstream.read( (char*)&curLayer.nlines, sizeof(int32_t) );
-        LOG( "    no.of lines: " << curLayer.nlines << '\n' );
 
         for( int nl = 0; nl < curLayer.nlines; ++nl )
         {
-            LOG( "    line " << nl << " ---------------------\n" );
             readLine( fstream, curLayer );
         }
 
@@ -135,27 +115,20 @@ namespace detail
         npages( 0 ), filename( openFilename )
     {
         std::string fullname = filename + ".lines";
-
-        LOG( "Opening file: " << fullname << '\n' );
         std::ifstream fstream( fullname, std::ios::binary );
 
         // skip header
         fstream.seekg( 43, fstream.beg );
-
         fstream.read( (char*)&npages, sizeof(int32_t) );
-        LOG( "no. of pages: " << npages << '\n' );
 
         for( int p = 0; p < npages; ++p )
         {
-            LOG( "page " << p << " -------------------------\n" );
             // layers
             Page curPage;
             fstream.read( (char*)&curPage.nlayers, sizeof(int32_t) );
-            LOG( "  no. of layers: " << curPage.nlayers << '\n' );
 
             for( int nlay = 0; nlay < curPage.nlayers; ++nlay )
             {
-                LOG( "  layer " << nlay << " ----------------------\n" );
                 detail::readLayer( fstream, curPage );
             }
 

--- a/include/rmlab/Notebook.cpp
+++ b/include/rmlab/Notebook.cpp
@@ -149,8 +149,6 @@ namespace detail
 
     void Notebook::save( std::string const saveFilename )
     {
-        std::cout << "Saving to file: " << saveFilename + std::string( ".lines" )
-                  << std::endl;
         std::ofstream fstream(
             saveFilename + std::string( ".lines" ),
             std::fstream::out | std::ios::binary

--- a/include/rmlab/Notebook.cpp
+++ b/include/rmlab/Notebook.cpp
@@ -26,6 +26,12 @@
 #include <fstream>
 #include <iostream>
 
+#ifdef RMLAB_ENABLE_LOGGING
+#define LOG(arg) (std::cerr << arg)
+#else
+#define LOG(arg)
+#endif
+
 
 namespace rmlab
 {
@@ -41,8 +47,8 @@ namespace detail
 
         fstream.read( (char*)&curPoint.x, sizeof(float) );
         fstream.read( (char*)&curPoint.y, sizeof(float) );
-        std::cout << "              coords: " << curPoint.x << ", "
-                  << curPoint.y << std::endl;
+        LOG( "              coords: " << curPoint.x << ", "
+                << curPoint.y << '\n' );
 
         // pressure and rotation of the pen to page normal
         // rotation: for centrially symmetric brushes as now, one attribute
@@ -54,9 +60,9 @@ namespace detail
         fstream.read( (char*)&curPoint.rotX, sizeof(float) );
         // range [-pi/2:pi/2]
         fstream.read( (char*)&curPoint.rotY, sizeof(float) );
-        std::cout << "            pressure: " << curPoint.pressure << std::endl;
-        std::cout << "       rot to X axis: " << curPoint.rotX << std::endl;
-        std::cout << "       rot to Y axis: " << curPoint.rotY << std::endl;
+        LOG( "            pressure: " << curPoint.pressure << '\n' );
+        LOG( "       rot to X axis: " << curPoint.rotX << '\n' );
+        LOG( "       rot to Y axis: " << curPoint.rotY << '\n' );
 
         curLine.points.emplace_back( curPoint );
     }
@@ -78,30 +84,30 @@ namespace detail
         // select 4:   5 (marker/highlighter: always color 0)
         // what is/was 6? :-)
         fstream.read( (char*)&curLine.brush_type, sizeof(int32_t) );
-        std::cout << "      brush type:  " << curLine.brush_type << std::endl;
+        LOG( "      brush type:  " << curLine.brush_type << '\n' );
 
         // color (0: black, 1: grey, 2: white)
         fstream.read( (char*)&curLine.color, sizeof(int32_t) );
-        std::cout << "      color int32: " << curLine.color << std::endl;
+        LOG( "      color int32: " << curLine.color << '\n' );
 
         // unknown 4 Byte (int32_t?), always zero?
         // non-stored information about "selected" lines?
         fstream.read( (char*)&curLine.unknown_line_attribute, sizeof(int32_t) );
-        std::cout << "      magic 4byte:  " << curLine.unknown_line_attribute << std::endl;
+        LOG( "      magic 4byte:  " << curLine.unknown_line_attribute << '\n' );
 
         // brush base size: 1.875, 2.0, 2.125
         fstream.read( (char*)&curLine.brush_base_size, sizeof(float) );
-        std::cout << "      brush size:  " << curLine.brush_base_size << std::endl;
+        LOG( "      brush size:  " << curLine.brush_base_size << '\n' );
 
         fstream.read( (char*)&curLine.npoints, sizeof(int32_t) );
-        std::cout << "      no. points: " << curLine.npoints << std::endl;
-        
+        LOG( "      no. points: " << curLine.npoints << '\n' );
+
         for( int n = 0; n < curLine.npoints; ++n )
         {
-            std::cout << "      point " << n << " --------------------" << std::endl;
+            LOG( "      point " << n << " --------------------\n" );
             readPoint( fstream, curLine );
         }
-        
+
         curLayer.lines.emplace_back( curLine );
     }
 
@@ -113,14 +119,14 @@ namespace detail
     {
         Layer curLayer;
         fstream.read( (char*)&curLayer.nlines, sizeof(int32_t) );
-        std::cout << "    no.of lines: " << curLayer.nlines << std::endl;
-        
+        LOG( "    no.of lines: " << curLayer.nlines << '\n' );
+
         for( int nl = 0; nl < curLayer.nlines; ++nl )
         {
-            std::cout << "    line " << nl << " ---------------------" << std::endl;
+            LOG( "    line " << nl << " ---------------------\n" );
             readLine( fstream, curLayer );
         }
-        
+
         curPage.layers.emplace_back( curLayer );
     }
 }
@@ -128,35 +134,34 @@ namespace detail
     Notebook::Notebook( std::string const openFilename ) :
         npages( 0 ), filename( openFilename )
     {
-        std::cout << "Opening file: " << filename + std::string( ".lines" ) << std::endl;
-        std::ifstream fstream(
-            filename + std::string( ".lines" ),
-            std::ios::binary
-        );
-        
+        std::string fullname = filename + ".lines";
+
+        LOG( "Opening file: " << fullname << '\n' );
+        std::ifstream fstream( fullname, std::ios::binary );
+
         // skip header
         fstream.seekg( 43, fstream.beg );
-        
+
         fstream.read( (char*)&npages, sizeof(int32_t) );
-        std::cout << "no.of pages: " << npages << std::endl;
-        
+        LOG( "no. of pages: " << npages << '\n' );
+
         for( int p = 0; p < npages; ++p )
         {
-            std::cout << "page " << p << " -------------------------" << std::endl;
+            LOG( "page " << p << " -------------------------\n" );
             // layers
             Page curPage;
             fstream.read( (char*)&curPage.nlayers, sizeof(int32_t) );
-            std::cout << "  no.o.layers: " << curPage.nlayers << std::endl;
+            LOG( "  no. of layers: " << curPage.nlayers << '\n' );
 
             for( int nlay = 0; nlay < curPage.nlayers; ++nlay )
             {
-                std::cout << "  layer " << nlay << " ----------------------" << std::endl;
+                LOG( "  layer " << nlay << " ----------------------\n" );
                 detail::readLayer( fstream, curPage );
             }
 
             pages.emplace_back( curPage );
         }
-        
+
         fstream.close();
     }
 

--- a/include/rmlab/tool/dump.cpp
+++ b/include/rmlab/tool/dump.cpp
@@ -1,0 +1,96 @@
+/* Copyright 2017-2018 Axel Huebl
+ *
+ * This file is part of lines-are-beautiful.
+ *
+ * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lines-are-beautiful is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lines-are-beautiful.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <rmlab/rmlab.hpp>
+
+#include <string>
+#include <iostream>
+#include <cmath>
+
+
+int
+main(
+    int argc,
+    char * argv[]
+)
+{
+    if( argc != 2 )
+    {
+        std::cerr << "Usage: " << argv[0] << " path/to/filePrefix" << std::endl;
+        return 1;
+    }
+
+    rmlab::Notebook notebook( argv[1] );
+
+    std::cout << "no. of pages: " << notebook.pages.size() << '\n';
+    std::size_t page_id = 0;
+
+    for( const auto & page : notebook.pages )
+    {
+        std::cout << "page " << page_id
+                  << " -------------------------\n"
+                  << "  no. of layers: " << page.layers.size() << '\n';
+
+        std::size_t layer_id = 0;
+
+        for( const auto & layer : page.layers )
+        {
+            std::cout << "  layer " << layer_id
+                      << " ----------------------\n"
+                      << "    no. of lines: " << layer.lines.size() << '\n';
+
+            std::size_t line_id = 0;
+
+            for( const auto & line : layer.lines )
+            {
+                std::cout << "    line " << line_id
+                          << " ---------------------\n"
+                          << "      brush type: " << line.brush_type << '\n'
+                          << "      color int32: " << line.color << '\n'
+                          << "      magic 4byte: "
+                                << line.unknown_line_attribute << '\n'
+                          << "      brush size: "
+                                << line.brush_base_size << '\n'
+                          << "      no. points: " << line.points.size() << '\n';
+
+                std::size_t point_id = 0;
+
+                for( const auto & point : line.points )
+                {
+                    std::cout << "      point " << point_id
+                              << " --------------------\n"
+                              << "        coords: "
+                                    << point.x << ", " << point.y << '\n'
+                              << "        pressure: " << point.pressure << '\n'
+                              << "        rot to X axis: " << point.rotX << '\n'
+                              << "        rot to Y axis: "
+                                    << point.rotY << '\n';
+
+                    ++point_id;
+                }
+
+                ++line_id;
+            }
+
+            ++layer_id;
+        }
+
+        ++page_id;
+    }
+}

--- a/include/rmlab/tool/dump.cpp
+++ b/include/rmlab/tool/dump.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Axel Huebl
+/* Copyright 2017-2018 Axel Huebl, Matteo Delabre
  *
  * This file is part of lines-are-beautiful.
  *
@@ -39,7 +39,7 @@ main(
     rmlab::Notebook notebook( argv[1] );
 
     std::cout << "no. of pages: " << notebook.pages.size() << '\n';
-    std::size_t page_id = 0;
+    std::size_t page_id = 0u;
 
     for( const auto & page : notebook.pages )
     {
@@ -47,7 +47,7 @@ main(
                   << " -------------------------\n"
                   << "  no. of layers: " << page.layers.size() << '\n';
 
-        std::size_t layer_id = 0;
+        std::size_t layer_id = 0u;
 
         for( const auto & layer : page.layers )
         {
@@ -55,7 +55,7 @@ main(
                       << " ----------------------\n"
                       << "    no. of lines: " << layer.lines.size() << '\n';
 
-            std::size_t line_id = 0;
+            std::size_t line_id = 0u;
 
             for( const auto & line : layer.lines )
             {
@@ -64,23 +64,23 @@ main(
                           << "      brush type: " << line.brush_type << '\n'
                           << "      color int32: " << line.color << '\n'
                           << "      magic 4byte: "
-                                << line.unknown_line_attribute << '\n'
+                          << line.unknown_line_attribute << '\n'
                           << "      brush size: "
-                                << line.brush_base_size << '\n'
+                          << line.brush_base_size << '\n'
                           << "      no. points: " << line.points.size() << '\n';
 
-                std::size_t point_id = 0;
+                std::size_t point_id = 0u;
 
                 for( const auto & point : line.points )
                 {
                     std::cout << "      point " << point_id
                               << " --------------------\n"
                               << "        coords: "
-                                    << point.x << ", " << point.y << '\n'
+                              << point.x << ", " << point.y << '\n'
                               << "        pressure: " << point.pressure << '\n'
                               << "        rot to X axis: " << point.rotX << '\n'
                               << "        rot to Y axis: "
-                                    << point.rotY << '\n';
+                              << point.rotY << '\n';
 
                     ++point_id;
                 }
@@ -93,4 +93,6 @@ main(
 
         ++page_id;
     }
+
+    return 0;
 }

--- a/include/rmlab/tool/dump.cpp
+++ b/include/rmlab/tool/dump.cpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/include/rmlab/writer/lineDemo.cpp
+++ b/include/rmlab/writer/lineDemo.cpp
@@ -2,7 +2,7 @@
  *
  * This file is part of lines-are-beautiful.
  *
- * lines-are-beautiful is free software: you can edistribute it and/or modify
+ * lines-are-beautiful is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.


### PR DESCRIPTION
Currently, the notebook decoder outputs various debugging information to the standard output while decoding files. While this output can be useful at times, it is, in my opinion, unnecessary for most users of the library. The proposed changes include:

* moving logging instructions behind a conditionally-compiled macro;
* adding a disabled-by-default CMake flag allowing users to manually turn on logging when needed;
* when disabled, compiling the logging macro to a noop, so as to not affect normal usage performance;
* when enabled, logging to the standard error stream instead of the standard output. If some parts of the library are further extended and need to output non-debugging information to the standard output, users that have enabled logging would still be able to distinguish the two kinds of information.