### PR TITLE
CMake: Add Rmlab::Rmlab ALIAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ endif()
 add_library(Rmlab
     include/rmlab/Notebook.cpp
 )
+add_library(Rmlab::Rmlab ALIAS Rmlab)
 
 if(NOT WIN32)
     target_link_libraries(Rmlab PRIVATE m)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ find_package(Rmlab 0.1.0 CONFIG)
 target_link_libraries(YourTarget PRIVATE Rmlab::Rmlab)
 ```
 
+*Alternatively*, add whole repository directly to your project and add it via:
+```cmake
+add_subdirectory("path/to/source/of/lines-are-beautiful")
+
+target_link_libraries(YourTarget PRIVATE Rmlab::Rmlab)
+```
+
 In your C++ files (see [Doxygen](https://ax3l.github.io/lines-are-beautiful/)):
 ```C++
 #include <rmlab/rmlab.hpp>


### PR DESCRIPTION
Adding an alias with the same name as the installed, exported target allows to include the full source-code of lines-are-beautiful (rmlab) in a project similar to header-only libraries.

Instead of starting with `find_package(Rmlab)`
```cmake
cmake_minimum_required(VERSION 3.7)

find_package(Rmlab 0.1.0 CONFIG REQUIRED)

add_executable(YourTarget yourTarget.cpp)

if(Rmlab_FOUND) # well, it will be if REQUIRED is set
    target_link_libraries(YourTarget PRIVATE Rmlab::Rmlab)
endif()
```

just do:
```cmake
cmake_minimum_required(VERSION 3.7)

add_executable(YourTarget yourTarget.cpp)

add_subdirectory(share/project/lines-are-beautiful)
target_link_libraries(YourTarget PRIVATE Rmlab::Rmlab)
```

Close #7