### PR TITLE
CMake: Honor _ROOT Env Hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,17 @@ cmake_minimum_required(VERSION 3.7)
 project(Rmlab VERSION 0.1.0 LANGUAGES CXX)
 
 
+################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+
 # Options and Variants ########################################################
 #
 function(rmlab_option name description default)

--- a/RmlabConfig.cmake.in
+++ b/RmlabConfig.cmake.in
@@ -2,6 +2,12 @@
 #   https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-a-package-configuration-file
 include(CMakeFindDependencyMacro)
 
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 set(Rmlab_HAVE_PNG @Rmlab_HAVE_PNG@)
 if(Rmlab_HAVE_PNG)
     find_dependency(PNGwriter)


### PR DESCRIPTION
CMake 3.12.0+ honor `<Package>_ROOT` environment hints which are often set on HPC systems. Previously, it was only looking for `<Package>_DIR` paths in `find_package` calls.

This new policy is useful since HPC systems usually set `_DIR`, `_ROOT` or expand the `CMAKE_PREFIX_PATH`. Therefore we want to use it as soon as it is available.

On systems where those env vars are set, e.g. Hypnos, this also throws a warning if the default (OLD) policy is used with CMake 3.12.4 or newer.

References:

- https://cmake.org/cmake/help/v3.12/policy/CMP0074.html